### PR TITLE
Run ruff

### DIFF
--- a/tests/api/test_endpoint.py
+++ b/tests/api/test_endpoint.py
@@ -8,14 +8,14 @@ from pypmanager.api import app
 client = TestClient(app)
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_root_endpoint() -> None:
     """Test endpoint /."""
     response = client.get("/")
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_favicon() -> None:
     """Test endpoint /favicon.ico."""
     response = client.get("/favicon.ico")

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -38,7 +38,7 @@ def _mock_transaction_list_graphql(
         yield
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_transaction_list_graphql")
 async def test_graphql_query__all_general_ledger() -> None:
     """Test query allGeneralLedger."""
@@ -68,7 +68,7 @@ async def test_graphql_query__all_general_ledger() -> None:
     assert len(response.json()["data"]["allGeneralLedger"]) == 6
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_transaction_list_graphql")
 async def test_graphql_query__current_portfolio() -> None:
     """Test query currentPortfolio."""
@@ -93,7 +93,7 @@ async def test_graphql_query__current_portfolio() -> None:
     assert response.status_code == 200
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_transaction_list_graphql")
 async def test_graphql_query__historical_portfolio(
     freezer: FrozenDateTimeFactory,
@@ -118,7 +118,7 @@ async def test_graphql_query__historical_portfolio(
     assert len(response.json()["data"]["historicalPortfolio"]) == 9
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_transaction_list_graphql")
 async def test_graphql_query__all_transaction() -> None:
     """Test query allTransaction."""
@@ -149,7 +149,7 @@ async def test_graphql_query__all_transaction() -> None:
     assert len(response.json()["data"]["allTransaction"]) == 2
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 @pytest.mark.usefixtures("_mock_transaction_list_graphql")
 async def test_graphql_query__result_statement() -> None:
     """Test query resultStatement."""

--- a/tests/general_ledger/test_ledger.py
+++ b/tests/general_ledger/test_ledger.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from tests.conftest import DataFactory
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_class_general_ledger(
     data_factory: type[DataFactory],
 ) -> None:

--- a/tests/ingest/transaction/test_helpers.py
+++ b/tests/ingest/transaction/test_helpers.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from tests.conftest import DataFactory
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_async_aggregate_ledger_by_year(
     data_factory: type[DataFactory],
 ) -> None:

--- a/tests/ingest/transaction/test_transaction_registry.py
+++ b/tests/ingest/transaction/test_transaction_registry.py
@@ -14,7 +14,7 @@ from pypmanager.settings import Settings
 from tests.conftest import DataFactory
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_transaction_registry(
     data_factory: type[DataFactory],
 ) -> None:
@@ -39,7 +39,7 @@ async def test_transaction_registry(
         assert len(registry) == 3
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_transaction_registry__all_sold(
     data_factory: type[DataFactory],
 ) -> None:
@@ -66,7 +66,7 @@ async def test_transaction_registry__all_sold(
         # calc_avg_price_per_unit
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_transaction_registry__date_filter(
     data_factory: type[DataFactory],
 ) -> None:
@@ -86,7 +86,7 @@ async def test_transaction_registry__date_filter(
         assert len(registry) == 1
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_transaction_registry__date_filter__raises(
     data_factory: type[DataFactory],
 ) -> None:
@@ -106,7 +106,7 @@ async def test_transaction_registry__date_filter__raises(
         ).async_get_registry()
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_transaction_registry__columns(
     data_factory: type[DataFactory],
 ) -> None:

--- a/tests/utils/test_dt.py
+++ b/tests/utils/test_dt.py
@@ -9,7 +9,7 @@ from pypmanager.settings import Settings
 from pypmanager.utils.dt import async_get_last_n_quarters, get_previous_quarter
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_async_get_last_n_quarters(
     freezer: FrozenDateTimeFactory,
 ) -> None:


### PR DESCRIPTION
This pull request includes updates to the `pytest.mark.asyncio` decorator across multiple test files to correct its usage. The changes ensure consistency and proper functionality of the asynchronous tests.

Changes to `pytest.mark.asyncio` decorator:

* [`tests/api/test_endpoint.py`](diffhunk://#diff-3b57af23221e342cd536c134639f4316b6155f236fb9cdc92069d2f301d6587aL11-R18): Removed unnecessary parentheses from `@pytest.mark.asyncio` decorator in `test_root_endpoint` and `test_favicon` functions.
* [`tests/api/test_graphql.py`](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL41-R41): Corrected `@pytest.mark.asyncio` decorator usage in multiple test functions, including `test_graphql_query__all_general_ledger`, `test_graphql_query__current_portfolio`, `test_graphql_query__historical_portfolio`, `test_graphql_query__all_transaction`, and `test_graphql_query__result_statement`. [[1]](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL41-R41) [[2]](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL71-R71) [[3]](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL96-R96) [[4]](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL121-R121) [[5]](diffhunk://#diff-b45bdcd6ce427bfdecf2b27d1798259e44727691ee02f999f131702edc8b138eL152-R152)
* [`tests/general_ledger/test_ledger.py`](diffhunk://#diff-fb298b2c683fdb54691a019282228a0ae5573b71e9aa4d459b64fbcf8df4aa13L17-R17): Updated `@pytest.mark.asyncio` decorator in `test_class_general_ledger` function.
* [`tests/ingest/transaction/test_helpers.py`](diffhunk://#diff-04dfee431d13b3671ae64ac8a5e4806723222e21fd0d4abefea43fdbe8fdab66L20-R20): Fixed `@pytest.mark.asyncio` decorator in `test_async_aggregate_ledger_by_year` function.
* [`tests/ingest/transaction/test_transaction_registry.py`](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L17-R17): Applied correct `@pytest.mark.asyncio` decorator in multiple test functions, including `test_transaction_registry`, `test_transaction_registry__all_sold`, `test_transaction_registry__date_filter`, `test_transaction_registry__date_filter__raises`, and `test_transaction_registry__columns`. [[1]](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L17-R17) [[2]](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L42-R42) [[3]](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L69-R69) [[4]](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L89-R89) [[5]](diffhunk://#diff-bed4b5b6eddb895a9760d8e6323ab73d032e3559507859ebba15ce6ba7d2e091L109-R109)
* [`tests/utils/test_dt.py`](diffhunk://#diff-de7a556734ffaea6b739cbdef6bc2e63749a3c599e511fabb32360ec03238876L12-R12): Adjusted `@pytest.mark.asyncio` decorator in `test_async_get_last_n_quarters` function.